### PR TITLE
Adding in all tests in the test-gym.th, adding default server

### DIFF
--- a/src/experiment.lua
+++ b/src/experiment.lua
@@ -2,7 +2,8 @@ local function experiment(envName, agent, nSteps, nIterations, opt)
    local util = require 'twrl.util'()
    local gymClient = require 'twrl.binding-lua.gym_http_client'
    local opt = opt or {}
-   local client = gymClient.new(opt.gymHttpServer)
+   gymHttpServer = opt.gymHttpServer or 'http://127.0.0.1:5000'
+   local client = gymClient.new(gymHttpServer)
    local instanceID = client:env_create(envName)
    local outdir = opt.outdir
    local video = opt.video

--- a/test/test-gym.lua
+++ b/test/test-gym.lua
@@ -65,7 +65,7 @@ function experiment.randomNoLearningNoModel()
 end
 
 tester:add(api)
-tester:add(atari):disable('testAtari')
-tester:add(mujoco):disable('testMujoco')
+tester:add(atari)
+tester:add(mujoco)
 tester:add(experiment)
 tester:run()


### PR DESCRIPTION
Testing now has unit tests and integration tests 
Removed disable for atari and mujoco testing.
This way testing will run and if it fails due to no Atari or Mujoco present, then it will show an error. 
Perhaps there is a more eloquent way for testing these.